### PR TITLE
Fixed deprecated unescaped left brace in regex

### DIFF
--- a/lib/Mustache/Simple.pm
+++ b/lib/Mustache/Simple.pm
@@ -591,7 +591,7 @@ sub read_file($)
     my $self = shift;
     my $file = shift;
     return '' unless $file;
-    return $file if $file =~ /{{/;
+    return $file if $file =~ /\{\{/;
     my $extension = $self->extension;
     (my $fullfile = $file) =~ s/(\.$extension)?$/.$extension/;
     my $filepath = getfile $self->path, $fullfile;


### PR DESCRIPTION
As of Perl v5.26, literal uses of a curly bracket will be required to be escaped